### PR TITLE
[FIX] 시스템 프롬프트 템플릿에 키워드들이 구분자 구분 없이 붙어서 나오는 이슈 해결

### DIFF
--- a/src/main/java/com/words_hanjoom/domain/feedback/service/FeedbackService.java
+++ b/src/main/java/com/words_hanjoom/domain/feedback/service/FeedbackService.java
@@ -138,7 +138,7 @@ public class FeedbackService {
                             "content", article.getContent()
                     ),
                     Map.of(
-                            "keywords", String.join(",", activity.getKeywords()),
+                            "keywords", String.join(", ", activity.getKeywords()),
                             "title", activity.getTitle(),
                             "category", activity.getCategory(),
                             "summary", activity.getSummary()

--- a/src/main/java/com/words_hanjoom/domain/feedback/service/FeedbackService.java
+++ b/src/main/java/com/words_hanjoom/domain/feedback/service/FeedbackService.java
@@ -138,7 +138,7 @@ public class FeedbackService {
                             "content", article.getContent()
                     ),
                     Map.of(
-                            "keywords", activity.getKeywords(),
+                            "keywords", String.join(",", activity.getKeywords()),
                             "title", activity.getTitle(),
                             "category", activity.getCategory(),
                             "summary", activity.getSummary()


### PR DESCRIPTION
예상: "초콜릿, 카카오, 미생물 군집, 발효"
실제: "초콜릿카카오미생물 군집발효"

예상 결과처럼 수정 완료